### PR TITLE
Defaults schema extra inputs behavior

### DIFF
--- a/src/migrations/forestry.js
+++ b/src/migrations/forestry.js
@@ -444,6 +444,8 @@ async function buildSchema(migrator, templatePath, extension) {
 				const schemaDef = {
 					path: filePath,
 					name: templateContents.label,
+					remove_extra_inputs: false,
+					hide_extra_inputs: true,
 					_enabled_editors: getEnabledEditors(extension, templateContents.hide_body),
 					_inputs: schema.inputConfig
 				};


### PR DESCRIPTION
Changed default behavior for Schemas to not remove extra inputs from the collection file.

The migrated file should have the following options set on `collections.schemas` configuration as per the documentation:
```
remove_extra_inputs: false
hide_extra_inputs: true
```

https://cloudcannon.com/documentation/articles/creating-collection-schemas/